### PR TITLE
2960 fridgetag datetime as local naive

### DIFF
--- a/src/berlinger.rs
+++ b/src/berlinger.rs
@@ -269,6 +269,7 @@ fn parse_timestamp(json_str: &Value) -> Option<NaiveDateTime> {
             None
         }
         Some(datetime_timestamp) => {
+            println!("got datetime_timestamp ok");
             NaiveDateTime::checked_sub_offset(datetime_timestamp, *Local::now().offset())
         }
     };
@@ -283,6 +284,7 @@ fn parse_date(json_str: &Value) -> Option<NaiveDate> {
             None
         }
         Some(date_timestamp) => {
+            println!("got date_timestamp ok");
             let time_delta =
                 TimeDelta::new(i64::from(Local::now().offset().fix().local_minus_utc()), 0);
             match time_delta {
@@ -305,6 +307,7 @@ fn parse_time(json_str: &Value) -> Option<NaiveTime> {
             None
         }
         Some(time_timestamp) => {
+            println!("got time_timestamp ok");
             let time_delta =
                 TimeDelta::new(i64::from(Local::now().offset().fix().local_minus_utc()), 0);
             match time_delta {

--- a/src/berlinger.rs
+++ b/src/berlinger.rs
@@ -3,6 +3,7 @@ use chrono::{
     DateTime, Duration, Local, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeDelta,
     TimeZone,
 };
+use log::info;
 use serde_json::{json, Value};
 use std::fs::File;
 use std::io;
@@ -263,7 +264,10 @@ fn parse_timestamp(json_str: &Value) -> Option<NaiveDateTime> {
     let parsed_string = parse_string(json_str);
     let datetime_timestamp = NaiveDateTime::parse_from_str(&parsed_string, "%Y-%m-%d %H:%M").ok();
     return match datetime_timestamp {
-        None => None,
+        None => {
+            info!("failed to parse str to NaiveDateTime");
+            None
+        }
         Some(datetime_timestamp) => {
             NaiveDateTime::checked_sub_offset(datetime_timestamp, *Local::now().offset())
         }
@@ -274,12 +278,18 @@ fn parse_date(json_str: &Value) -> Option<NaiveDate> {
     let parsed_string = parse_string(json_str);
     let date_timestamp = NaiveDate::parse_from_str(&parsed_string, "%Y-%m-%d").ok();
     return match date_timestamp {
-        None => None,
+        None => {
+            info!("failed to parse str to NaiveDate");
+            None
+        }
         Some(date_timestamp) => {
             let time_delta =
                 TimeDelta::new(i64::from(Local::now().offset().fix().local_minus_utc()), 0);
             match time_delta {
-                None => None,
+                None => {
+                    info!("failed to generate time_delta for NaiveDate");
+                    None
+                }
                 Some(time_delta) => NaiveDate::checked_sub_signed(date_timestamp, time_delta),
             }
         }
@@ -290,12 +300,18 @@ fn parse_time(json_str: &Value) -> Option<NaiveTime> {
     let parsed_string = parse_string(json_str);
     let time_timestamp = NaiveTime::parse_from_str(&parsed_string, "%H:%M").ok();
     return match time_timestamp {
-        None => None,
+        None => {
+            info!("failed to parse str to NaiveTime");
+            None
+        }
         Some(time_timestamp) => {
             let time_delta =
                 TimeDelta::new(i64::from(Local::now().offset().fix().local_minus_utc()), 0);
             match time_delta {
-                None => None,
+                None => {
+                    info!("failed to generate time_delta for NaiveTime");
+                    None
+                }
                 Some(time_delta) => {
                     return Some(NaiveTime::overflowing_sub_signed(&time_timestamp, time_delta).0);
                 }

--- a/src/berlinger.rs
+++ b/src/berlinger.rs
@@ -1,4 +1,6 @@
-use chrono::{Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeDelta, TimeZone};
+use chrono::{
+    naive, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeDelta, TimeZone,
+};
 use log::info;
 use serde_json::{json, Value};
 use std::fs::File;
@@ -264,69 +266,28 @@ fn parse_timestamp(json_str: &Value) -> Option<NaiveDateTime> {
             info!("failed to parse str to NaiveDateTime");
             None
         }
-        Some(datetime_timestamp) => {
-            let local_datetime_timestamp = match Local.from_local_datetime(&datetime_timestamp) {
-                chrono::LocalResult::None => None,
-                chrono::LocalResult::Ambiguous(r, _) => Some(r.naive_utc()),
-                chrono::LocalResult::Single(r) => Some(r.naive_utc()),
-            };
-            local_datetime_timestamp
-            //         println!("got datetime_timestamp ok");
-            //         let naive_datetime =
-            //             NaiveDateTime::checked_sub_offset(datetime_timestamp, *Local::now().offset());
-            //         println!("got this naive_datetime: {:?}", naive_datetime);
-            //         naive_datetime
-            //     }
-        }
+        Some(datetime) => match Local.from_local_datetime(&datetime) {
+            chrono::LocalResult::None => None,
+            chrono::LocalResult::Ambiguous(r, _) => Some(r.naive_utc()),
+            chrono::LocalResult::Single(r) => Some(r.naive_utc()),
+        },
     };
 }
 
 fn parse_date(json_str: &Value) -> Option<NaiveDate> {
-    let parsed_string = parse_string(json_str);
-    NaiveDate::parse_from_str(&parsed_string, "%Y-%m-%d").ok()
-    // return match date_timestamp {
-    //     None => {
-    //         info!("failed to parse str to NaiveDate");
-    //         None
-    //     }
-    //     Some(date_timestamp) => {
-    //         println!("got date_timestamp ok");
-    //         let time_delta =
-    //             TimeDelta::new(i64::from(Local::date().offset().fix().local_minus_utc()), 0);
-    //         match time_delta {
-    //             None => {
-    //                 info!("failed to generate time_delta for NaiveDate");
-    //                 None
-    //             }
-    //             Some(time_delta) => NaiveDate::checked_sub_signed(date_timestamp, time_delta),
-    //         }
-    //     }
-    // };
+    let datetime = parse_timestamp(json_str);
+    match datetime {
+        None => None,
+        Some(datetime) => Some(datetime.date()),
+    }
 }
 
 fn parse_time(json_str: &Value) -> Option<NaiveTime> {
-    let parsed_string = parse_string(json_str);
-    let time_timestamp = NaiveTime::parse_from_str(&parsed_string, "%H:%M").ok();
-    return match time_timestamp {
-        None => {
-            info!("failed to parse str to NaiveTime");
-            None
-        }
-        Some(time_timestamp) => {
-            println!("got time_timestamp ok");
-            let time_delta =
-                TimeDelta::new(i64::from(Local::now().offset().fix().local_minus_utc()), 0);
-            match time_delta {
-                None => {
-                    info!("failed to generate time_delta for NaiveTime");
-                    None
-                }
-                Some(time_delta) => {
-                    return Some(NaiveTime::overflowing_sub_signed(&time_timestamp, time_delta).0);
-                }
-            }
-        }
-    };
+    let datetime = parse_timestamp(json_str);
+    match datetime {
+        None => None,
+        Some(datetime) => Some(datetime.time()),
+    }
 }
 
 fn parse_int(json_str: &Value) -> Option<i64> {

--- a/src/berlinger.rs
+++ b/src/berlinger.rs
@@ -1,8 +1,4 @@
-use chrono::{
-    format::{parse, Parsed, StrftimeItems},
-    DateTime, Duration, Local, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeDelta,
-    TimeZone,
-};
+use chrono::{Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeDelta};
 use log::info;
 use serde_json::{json, Value};
 use std::fs::File;
@@ -270,7 +266,10 @@ fn parse_timestamp(json_str: &Value) -> Option<NaiveDateTime> {
         }
         Some(datetime_timestamp) => {
             println!("got datetime_timestamp ok");
-            NaiveDateTime::checked_sub_offset(datetime_timestamp, *Local::now().offset())
+            let naive_datetime =
+                NaiveDateTime::checked_sub_offset(datetime_timestamp, *Local::now().offset());
+            println!("got this naive_datetime: {:?}", naive_datetime);
+            naive_datetime
         }
     };
 }

--- a/src/berlinger.rs
+++ b/src/berlinger.rs
@@ -263,7 +263,11 @@ fn parse_timestamp(json_str: &Value) -> Option<NaiveDateTime> {
     let datetime_timestamp = NaiveDateTime::parse_from_str(&parsed_string, "%Y-%m-%d %H:%M").ok();
     return match datetime_timestamp {
         None => None,
-        Some(datetime) => NaiveDateTime::checked_add_offset(datetime, *Local::now().offset()),
+        Some(datetime) => {
+            let result = NaiveDateTime::checked_add_offset(datetime, *Local::now().offset());
+            println!("result: {:?}", result);
+            return result;
+        }
     };
 }
 

--- a/src/berlinger.rs
+++ b/src/berlinger.rs
@@ -259,17 +259,21 @@ fn parse_timestamp(json_str: &Value) -> Option<NaiveDateTime> {
     let parsed_string = parse_string(json_str);
     let datetime_timestamp =
         NaiveDateTime::parse_from_str(&parsed_string, "%Y-%m-%d %H:%M").unwrap();
+    println!("datetime_timestamp {:?}", datetime_timestamp);
     let local = match Local.from_local_datetime(&datetime_timestamp) {
         LocalResult::None => return None,
         LocalResult::Single(r) => r,
         LocalResult::Ambiguous(r, _) => r,
     };
+    println!("local {:?}", local);
     Some(local.naive_utc())
 }
 
 fn parse_date(json_str: &Value) -> Option<NaiveDate> {
     let parsed_string = parse_string(json_str);
     let date_timestamp = NaiveDateTime::parse_from_str(&parsed_string, "%Y-%m-%d %H:%M").unwrap();
+    println!("date_timestamp {:?}", date_timestamp);
+
     let local = match Local.from_local_datetime(&date_timestamp) {
         LocalResult::None => return None,
         LocalResult::Single(r) => r,
@@ -277,12 +281,14 @@ fn parse_date(json_str: &Value) -> Option<NaiveDate> {
     }
     .naive_utc()
     .date();
+    println!("local {:?}", local);
     Some(local)
 }
 
 fn parse_time(json_str: &Value) -> Option<NaiveTime> {
     let parsed_string = parse_string(json_str);
     let time_timestamp = NaiveDateTime::parse_from_str(&parsed_string, "%H:%M").unwrap();
+    println!("time_timestamp {:?}", time_timestamp);
     let local = match Local.from_local_datetime(&time_timestamp) {
         LocalResult::None => return None,
         LocalResult::Single(r) => r,
@@ -290,6 +296,7 @@ fn parse_time(json_str: &Value) -> Option<NaiveTime> {
     }
     .naive_utc()
     .time();
+    println!("local {:?}", local);
     Some(local)
 }
 

--- a/src/berlinger.rs
+++ b/src/berlinger.rs
@@ -264,7 +264,7 @@ fn parse_timestamp(json_str: &Value) -> Option<NaiveDateTime> {
     return match datetime_timestamp {
         None => None,
         Some(datetime) => {
-            let result = NaiveDateTime::checked_add_offset(datetime, *Local::now().offset());
+            let result = NaiveDateTime::checked_sub_offset(datetime, *Local::now().offset());
             println!("result: {:?}", result);
             return result;
         }


### PR DESCRIPTION
fixes [#2960](https://github.com/msupply-foundation/open-msupply/issues/2690)

Converts time into the local naive datetime as utc.

There are some caveats to this implementation (or any implementation that I can think of): 
When users originally set up the sensors, they may set it up in DST or out of DST. As the sensor moves in and out of DST ignorantly, it will cease to record the correct time, and be out by an hour. This will cause the jumps mentioned in discussion [here](https://github.com/msupply-foundation/open-msupply/issues/2690#issuecomment-1885092383).

An alternative implementation could be to manually parse times with the current local offset at the time of upload as per [this commit](https://github.com/msupply-foundation/temperature-sensor/pull/1/commits/c6c09d0b793150f7f666b3abf6a8cbcb11875e44). However this would introduce other issues of being in the wrong time for time uploads in a different DST. ie if you upload sensor data in DST - any times uploaded from out of DST will be wrong out by an hour. This method would avoid DST time jumps, however!

With timezone and DST ignorant data, I can't think of a way to parse breach data without assuming the DST status of the sensor or the locale of the sensor. All of this depends on user behaviour patterns which I can't think of a way to ensure.

I think this PR is better than the current (because it is at least within 1 hour of actual breach times), and for regular uploads and a user awareness of DST changes, this will give data much closer to the truth. 

I wonder if the most simple solution would be to ask users to re calibrate sensor time settings upon DST changes. Is this reasonable to ask of users? 

Maybe needs more discussion!

